### PR TITLE
Replace illegal characters for file names

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ function saveToQRCodes(accounts){
   }
 
   accounts.forEach(account => {
-    const name = account.name || ""
+    const name = account.name ? account.name.replace(/[<>:"\/\\|?*]/g, '_') : ""
     const issuer = account.issuer || ""
     const secret = account.totpSecret
 


### PR DESCRIPTION
This PR fixes file names replacing illegal characters.

E.g. it is impossible to create "GitHub (GitHub:OperKH).png" file in my case - it creates empty "GitHub (GitHub" file instead