### PR TITLE
Fix sanitizeFilename

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ function saveToQRCodes(accounts){
   }
 
   /** Windows is picky with filenames. */
-  const sanitizeFilename = (filename) => { filename.replace(/[\<>:"\/\\|?*#%&{}$+!`'=@]/g, "") }
+  const sanitizeFilename = (filename) => filename.replace(/[\<>:"\/\\|?*#%&{}$+!`'=@]/g, "")
   
   accounts.forEach(account => {
     const name = account.name || ""


### PR DESCRIPTION
Curly brackets with no return statement meant the function was always returning `undefined`, so the name part of filenames was always `(undefined)`, which causes a lot of filename collisions.

Thanks for this project by the way. Just used it in combination with zbar to quickly migrate off of Google Authenticator.